### PR TITLE
Add support for inheritance

### DIFF
--- a/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.Generator_TypeWithBaseClass_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.Generator_TypeWithBaseClass_GeneratesSuccessfully.approved.txt
@@ -1,0 +1,7 @@
+declare namespace Api {
+  interface TypeWithBaseClass extends BaseClass {
+  }
+  interface BaseClass {
+    property: string;
+  }
+}

--- a/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.Generator_TypeWithGenericParent_ShouldRenderValidTypescript.approved.txt
+++ b/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.Generator_TypeWithGenericParent_ShouldRenderValidTypescript.approved.txt
@@ -1,0 +1,4 @@
+declare namespace Api {
+  interface TypeWithGenericParent {
+  }
+}

--- a/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.cs
+++ b/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.cs
@@ -25,10 +25,25 @@ namespace Typescript.Tests.Inheritence
             var generator = TypeScriptGenerator.CreateDefault();
             var generated = generator.Generate(new[] {typeof(TypeWithBaseClass) });
 
-            var result = generated.Types;
-
-            this.Assent(result);
+            this.Assent(generated.Types);
         }
 
+
+        class TypeWithGenericParent : GenericParent<TypeWithGenericParent>
+        {
+
+        }
+        class GenericParent<T>
+        {
+        }
+
+        [Fact]
+        public void Generator_TypeWithGenericParent_ShouldRenderValidTypescript()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] { typeof(TypeWithGenericParent) });
+
+            this.Assent(generated.Types);
+        }
     }
 }

--- a/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.cs
+++ b/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Assent;
+using Typescriptr;
+using Typescriptr.Formatters;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Typescript.Tests.Inheritence
+{
+    public class InheritenceGeneratorTests
+    {
+        class BaseClass
+        {
+            public string Property { get; set; }
+        }
+
+        class TypeWithBaseClass : BaseClass
+        {
+            
+        }
+
+        [Fact]
+        public void Generator_TypeWithBaseClass_GeneratesSuccessfully()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] {typeof(TypeWithBaseClass) });
+
+            var result = generated.Types;
+
+            this.Assent(result);
+        }
+
+    }
+}

--- a/src/Typescriptr/TypeScriptGenerator.cs
+++ b/src/Typescriptr/TypeScriptGenerator.cs
@@ -211,7 +211,7 @@ namespace Typescriptr
             builder.AppendLine("}");
             _typesGenerated.Add(type);
 
-            if (hasBaseType)
+            if (hasBaseType && !baseIsGeneric)
                 if (!_typesGenerated.Contains(baseType))
                     _typeStack.Push(baseType);
         }

--- a/src/Typescriptr/TypeScriptGenerator.cs
+++ b/src/Typescriptr/TypeScriptGenerator.cs
@@ -181,9 +181,10 @@ namespace Typescriptr
             }
             var baseType = type.BaseType;
             var hasBaseType = ShouldExport(baseType);
+            var baseIsGeneric = baseType.IsGenericType;
 
             builder.Append($"interface {type.Name}");
-            if (hasBaseType) {
+            if (hasBaseType && !baseIsGeneric) {
                 builder.Append($" extends {baseType.Name}");
             }
 
@@ -202,7 +203,7 @@ namespace Typescriptr
                 if (_useCamelCasePropertyNames)
                     memberName = memberName.ToCamelCase();
 
-                if (memberInfo.DeclaringType == type) {
+                if (baseIsGeneric || memberInfo.DeclaringType == type) {
                     RenderProperty(builder, memberType, memberName);
                 }
             }


### PR DESCRIPTION
This change adds support for inheritance by adding `extends` to the generated `typescript` if the source CSharp uses inheritence. Properties of the base class are also inherited through the base type.

*Example*

```
class BaseClass
{
    public string Property { get; set; }
}

class TypeWithBaseClass : BaseClass
{           
}
```

The CSharp code above generates the following:

```
interface TypeWithBaseClass extends BaseClass {
}
interface BaseClass {
  property: string;
}
```
