### PR TITLE
Add support for custom dictionaries

### DIFF
--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithCustomDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithCustomDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
@@ -1,0 +1,7 @@
+declare namespace Api {
+  interface TypeWithCustomDictionaryProp {
+    dictProp: { [key: string]: number };
+  }
+}
+
+---

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.cs
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.cs
@@ -40,6 +40,24 @@ namespace Typescript.Tests.DictionaryTypes
             this.Assent(generated.Types);
         }
 
+        class TypeWithCustomDictionaryProp
+        {
+            public ICustomDictionary DictProp { get; set; }
+        }
+
+        interface ICustomDictionary : IDictionary<string, int>
+        {
+        }
+        
+        [Fact]
+        public void Generator_TypeWithCustomDictionaryValueType_ShouldRenderToTypescriptMap()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] {typeof(TypeWithCustomDictionaryProp)});
+
+            this.Assent(generated.JoinTypesAndEnums());
+        }
+
         enum TestEnum
         {
             FirstValue,
@@ -60,6 +78,5 @@ namespace Typescript.Tests.DictionaryTypes
 
             this.Assent(generated.JoinTypesAndEnums());
         }
-
     }
 }

--- a/src/Typescriptr/Traverse.cs
+++ b/src/Typescriptr/Traverse.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace Typescriptr
+{
+    internal static class Traverse
+    {
+        public static IEnumerable<T> Across<T>(T first, Func<T, T> next) where T : class
+        {
+            for (var item = first; item != null; item = next(item))
+                yield return item;
+        }
+    }
+}

--- a/src/Typescriptr/TypeExtensions.cs
+++ b/src/Typescriptr/TypeExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Typescriptr
+{
+    internal static class TypeExtensions
+    {
+        public static bool IsClosedTypeOf(this Type @this, Type openGeneric)
+        {
+            return TypesAssignableFrom(@this).Any(t =>
+            {
+                if (!t.GetTypeInfo().IsGenericType || @this.GetTypeInfo().ContainsGenericParameters) return false;
+                return t.GetGenericTypeDefinition() == openGeneric;
+            });
+        }
+
+        private static IEnumerable<Type> TypesAssignableFrom(Type candidateType)
+        {
+            return candidateType.GetTypeInfo().ImplementedInterfaces
+                .Concat(Traverse.Across(candidateType, t => t.GetTypeInfo().BaseType));
+        }
+    }
+}

--- a/src/Typescriptr/TypeScriptGenerator.cs
+++ b/src/Typescriptr/TypeScriptGenerator.cs
@@ -252,7 +252,7 @@ namespace Typescriptr
             if (_propTypeMap.ContainsKey(type))
                 return decorate(_propTypeMap[type]);
 
-            if (typeof(IDictionary).IsAssignableFrom(type))
+            if (type.IsClosedTypeOf(typeof(IDictionary<,>)))
                 return decorate(_dictionaryPropertyFormatter(type, TypeNameRenderer));
 
             if (typeof(IEnumerable).IsAssignableFrom(type))


### PR DESCRIPTION
This change adds support for custom dictionaries by checking for implementations of `IDictionary<,>`.

_Example_

```
interface ICustomDictionary : IDictionary<string, int>
{
}

class TypeWithCustomDictionaryProp
{
    public ICustomDictionary DictProp { get; set; }
}
```
generates:

```
declare namespace Api {
  interface TypeWithCustomDictionaryProp {
    dictProp: { [key: string]: number };
  }
}
```

Also, hiya :wave: nice work on Typecriptr. Very useful - nice and lightweight with good extensibility.