### PR TITLE
Add support for shared enums

### DIFF
--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyGenerateTheEnumOnce.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyGenerateTheEnumOnce.approved.txt
@@ -1,0 +1,15 @@
+declare namespace Api {
+  interface TypeTwoWithEnum {
+    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
+  }
+  interface TypeOneWithEnum {
+    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
+  }
+}
+
+---
+enum SharedEnumType {
+  FirstEnum = 'FirstEnum',
+  SecondEnum = 'SecondEnum',
+  ThirdEnum = 'ThirdEnum',
+}

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.cs
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.cs
@@ -74,5 +74,34 @@ namespace Typescript.Tests.Enums
 
             this.Assent(generated.JoinTypesAndEnums());
         }
+
+        
+        class TypeOneWithEnum
+        {
+            public SharedEnumType AnEnum { get; set; }
+        }
+        class TypeTwoWithEnum
+        {
+            public SharedEnumType AnEnum { get; set; }
+        }
+
+        public enum SharedEnumType
+        {
+            FirstEnum,
+            SecondEnum,
+            ThirdEnum
+        }
+        
+        [Fact]
+        public void Generator_TypesWithSharedEnum_ShouldOnlyGenerateTheEnumOnce()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] {typeof(TypeOneWithEnum), typeof(TypeTwoWithEnum)});
+
+            var result = string.Join($"{Environment.NewLine}---{Environment.NewLine}", generated.Types,
+                generated.Enums);
+
+            this.Assent(result);
+        }
     }
 }

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.cs
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.cs
@@ -1,7 +1,6 @@
 using System;
 using Assent;
 using Typescriptr;
-using Typescriptr.Formatters;
 using Xunit;
 
 namespace Typescript.Tests.Enums
@@ -98,10 +97,7 @@ namespace Typescript.Tests.Enums
             var generator = TypeScriptGenerator.CreateDefault();
             var generated = generator.Generate(new[] {typeof(TypeOneWithEnum), typeof(TypeTwoWithEnum)});
 
-            var result = string.Join($"{Environment.NewLine}---{Environment.NewLine}", generated.Types,
-                generated.Enums);
-
-            this.Assent(result);
+            this.Assent(generated.JoinTypesAndEnums());
         }
     }
 }

--- a/src/Typescriptr/TypeScriptGenerator.cs
+++ b/src/Typescriptr/TypeScriptGenerator.cs
@@ -160,9 +160,10 @@ namespace Typescriptr
 
         private void RenderEnum(StringBuilder builder, Type enumType)
         {
+            if (_enumNames.Contains(enumType.FullName)) return;
             var enumString = _enumFormatter(enumType, _quoteStyle);
             builder.Append(enumString);
-            _enumNames.Add(enumType.Name);
+            _enumNames.Add(enumType.FullName);
         }
 
         private void RenderType(StringBuilder builder, Type type)


### PR DESCRIPTION
Adds support for enums used by more than one type.

_Example_

```
public enum SharedEnumType
{
    FirstEnum,
    SecondEnum,
    ThirdEnum
}
class TypeOneWithEnum
{
    public SharedEnumType AnEnum { get; set; }
}
class TypeTwoWithEnum
{
    public SharedEnumType AnEnum { get; set; }
}
```
Expected:

`enums.ts` should contain one instance of `SharedEnumType`

Current:

<img src="https://user-images.githubusercontent.com/5088479/48965547-3dfb8380-f00b-11e8-9ce1-7f4a81883e6a.png" width="350" />
