### PR TITLE
Issue - shared enums decorated twice

### DIFF
--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyDecorateTheEnumOnce.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyDecorateTheEnumOnce.approved.txt
@@ -1,0 +1,18 @@
+declare namespace Api {
+  // Source: Typescript.Tests.Enums.EnumGeneratorTests+TypeTwoWithEnum
+  interface TypeTwoWithEnum {
+    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
+  }
+  // Source: Typescript.Tests.Enums.EnumGeneratorTests+TypeOneWithEnum
+  interface TypeOneWithEnum {
+    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
+  }
+}
+
+---
+// Source: Typescript.Tests.Enums.EnumGeneratorTests+SharedEnumType
+enum SharedEnumType {
+  FirstEnum = 'FirstEnum',
+  SecondEnum = 'SecondEnum',
+  ThirdEnum = 'ThirdEnum',
+}

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.cs
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Assent;
 using Typescriptr;
+using Typescriptr.Formatters;
 using Xunit;
 
 namespace Typescript.Tests.Enums
@@ -71,7 +72,6 @@ namespace Typescript.Tests.Enums
             this.Assent(generated.JoinTypesAndEnums());
         }
 
-        
         class TypeOneWithEnum
         {
             public SharedEnumType AnEnum { get; set; }
@@ -92,6 +92,17 @@ namespace Typescript.Tests.Enums
         public void Generator_TypesWithSharedEnum_ShouldOnlyGenerateTheEnumOnce()
         {
             var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] {typeof(TypeOneWithEnum), typeof(TypeTwoWithEnum)});
+
+            this.Assent(generated.JoinTypesAndEnums());
+        }
+
+        [Fact]
+        public void Generator_TypesWithSharedEnum_ShouldOnlyDecorateTheEnumOnce()
+        {
+            var generator = TypeScriptGenerator.CreateDefault()
+                .WithTypeDecorator(SourceLocationCommentDecorator.Decorate);
+
             var generated = generator.Generate(new[] {typeof(TypeOneWithEnum), typeof(TypeTwoWithEnum)});
 
             this.Assent(generated.JoinTypesAndEnums());

--- a/src/Typescriptr/TypeScriptGenerator.cs
+++ b/src/Typescriptr/TypeScriptGenerator.cs
@@ -147,10 +147,7 @@ namespace Typescriptr
             {
                 var type = _typeStack.Pop();
                 if (_typesGenerated.Contains(type)) continue;
-
-                if (_typeDecorator != null)
-                    (type.IsEnum ? enumBuilder : typeBuilder).AppendLine(_typeDecorator(type));
-
+                
                 if (type.IsEnum) RenderEnum(enumBuilder, type);
                 else RenderType(typeBuilder, type);
             }
@@ -173,6 +170,10 @@ namespace Typescriptr
         {
             if (_enumNames.Contains(enumType.FullName)) return;
             var enumString = _enumFormatter(enumType, _quoteStyle);
+            
+            if (_typeDecorator != null)
+                builder.AppendLine(_typeDecorator(enumType));
+
             builder.Append(enumString);
             _enumNames.Add(enumType.FullName);
         }
@@ -193,6 +194,9 @@ namespace Typescriptr
             }
             var baseType = type.BaseType;
             var hasBaseType = ShouldExport(baseType);
+            
+            if (_typeDecorator != null)
+                builder.AppendLine(_typeDecorator(type));
 
             builder.Append($"interface ");
             RenderTypeName(builder, type);


### PR DESCRIPTION
Turns out there _was_ a reason to split the check

Steps:
```c#
var generator = TypeScriptGenerator.CreateDefault()
    .WithTypeDecorator(SourceLocationCommentDecorator.Decorate);

var generated = generator.Generate(new[] {typeof(TypeOneWithEnum), typeof(TypeTwoWithEnum)});

this.Assent(generated.JoinTypesAndEnums());
```

Expected:
```ts
---
// Source: Typescript.Tests.Enums.EnumGeneratorTests+SharedEnumType
enum SharedEnumType {
  FirstEnum = 'FirstEnum',
  SecondEnum = 'SecondEnum',
  ThirdEnum = 'ThirdEnum',
}
```

Actual:

```ts
---
// Source: Typescript.Tests.Enums.EnumGeneratorTests+SharedEnumType
enum SharedEnumType {
  FirstEnum = 'FirstEnum',
  SecondEnum = 'SecondEnum',
  ThirdEnum = 'ThirdEnum',
}
// Source: Typescript.Tests.Enums.EnumGeneratorTests+SharedEnumType
```

I saw you added develop - doesn't look like it has shared enums yet though. Let me know if you merge it and I'll re-target the PR