### PR TITLE
BREAKING CHANGE: Switch off module nesting by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ public static TypeScriptGenerator CreateDefault() => new TypeScriptGenerator()
             .WithMemberFilter(() => true))
             .WithDictionaryPropertyFormatter(DictionaryPropertyFormatter.KeyValueFormatter)
             .WithCollectionPropertyFormatter(CollectionPropertyFormatter.Format)
-            .WithNamespace("Api")
             .WithCamelCasedPropertyNames()
 	    .WithMemberFilter(() => true);
 ```
@@ -95,10 +94,8 @@ class TypeWithEnum
 
 produces `result.Types`:
 ```TypeScript
-declare namespace Api {
-  interface TypeWithEnum {
-    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
-  }
+interface TypeWithEnum {
+  anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
 }
 ```
 and `result.Enums`:
@@ -130,10 +127,8 @@ class TypeWithDictionaryProp
 ```
 produces
 ```TypeScript
-declare namespace Api {
-  interface TypeWithDictionaryProp {
-    dictProp: { [key: string]: number };
-  }
+interface TypeWithDictionaryProp {
+  dictProp: { [key: string]: number };
 }
 ```
 
@@ -149,10 +144,8 @@ class TypeWithArrayProp
 ```
 produces:
 ```TypeScript
-declare namespace Api {
-  interface TypeWithArrayProp {
-    arrayProp: string[];
-  }
+interface TypeWithArrayProp {
+  arrayProp: string[];
 }
 ```
 
@@ -183,11 +176,9 @@ class TypeWithNullable
 ```
 
 ```TypeScript
-declare namespace Api {
-  interface TypeWithNullable {
-    nullableInt: number | null;
-    nullableGuid: string | null;
-  }
+interface TypeWithNullable {
+  nullableInt: number | null;
+  nullableGuid: string | null;
 }
 ```
 

--- a/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithArrayProperty_ShouldRenderToArray.approved.txt
+++ b/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithArrayProperty_ShouldRenderToArray.approved.txt
@@ -1,5 +1,4 @@
-declare module 'Api' {
-  export interface TypeWithArrayProp {
-    arrayProp: string[];
-  }
+export interface TypeWithArrayProp {
+  arrayProp: string[];
 }
+

--- a/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithArrayProperty_ShouldRenderToArray.approved.txt
+++ b/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithArrayProperty_ShouldRenderToArray.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithArrayProp {
+declare module 'Api' {
+  export interface TypeWithArrayProp {
     arrayProp: string[];
   }
 }

--- a/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithEnumerableProp_ShouldRenderToArray.approved.txt
+++ b/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithEnumerableProp_ShouldRenderToArray.approved.txt
@@ -1,5 +1,4 @@
-declare module 'Api' {
-  export interface TypeWithEnumerableProp {
-    enumerableProp: number[];
-  }
+export interface TypeWithEnumerableProp {
+  enumerableProp: number[];
 }
+

--- a/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithEnumerableProp_ShouldRenderToArray.approved.txt
+++ b/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithEnumerableProp_ShouldRenderToArray.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithEnumerableProp {
+declare module 'Api' {
+  export interface TypeWithEnumerableProp {
     enumerableProp: number[];
   }
 }

--- a/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithPropThatDerivesFromEnumerable_ShouldRenderToArray.approved.txt
+++ b/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithPropThatDerivesFromEnumerable_ShouldRenderToArray.approved.txt
@@ -1,5 +1,4 @@
-declare module 'Api' {
-  export interface TypeWithPropThatInheritsFromIEnumerable {
-    derivedFromList: number[];
-  }
+export interface TypeWithPropThatInheritsFromIEnumerable {
+  derivedFromList: number[];
 }
+

--- a/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithPropThatDerivesFromEnumerable_ShouldRenderToArray.approved.txt
+++ b/src/Typescript.Tests/CollectionTypes/CollectionGeneratorTests.Generator_TypeWithPropThatDerivesFromEnumerable_ShouldRenderToArray.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithPropThatInheritsFromIEnumerable {
+declare module 'Api' {
+  export interface TypeWithPropThatInheritsFromIEnumerable {
     derivedFromList: number[];
   }
 }

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithComplexDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithComplexDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
@@ -1,8 +1,7 @@
-declare module 'Api' {
-  export interface TypeWithComplexDictionaryValue {
-    dictProp: { [key: number]: ComplexType };
-  }
-  export interface ComplexType {
-    aProp: string;
-  }
+export interface TypeWithComplexDictionaryValue {
+  dictProp: { [key: number]: ComplexType };
 }
+export interface ComplexType {
+  aProp: string;
+}
+

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithComplexDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithComplexDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
@@ -1,8 +1,8 @@
-declare namespace Api {
-  interface TypeWithComplexDictionaryValue {
+declare module 'Api' {
+  export interface TypeWithComplexDictionaryValue {
     dictProp: { [key: number]: ComplexType };
   }
-  interface ComplexType {
+  export interface ComplexType {
     aProp: string;
   }
 }

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithCustomDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithCustomDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
@@ -1,7 +1,6 @@
-declare module 'Api' {
-  export interface TypeWithCustomDictionaryProp {
-    dictProp: { [key: string]: number };
-  }
+export interface TypeWithCustomDictionaryProp {
+  dictProp: { [key: string]: number };
 }
+
 
 ---

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithCustomDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithCustomDictionaryValueType_ShouldRenderToTypescriptMap.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithCustomDictionaryProp {
+declare module 'Api' {
+  export interface TypeWithCustomDictionaryProp {
     dictProp: { [key: string]: number };
   }
 }

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithDirectDictionaryProp_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithDirectDictionaryProp_ShouldRenderToTypescriptMap.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithDictionaryProp {
+declare module 'Api' {
+  export interface TypeWithDictionaryProp {
     dictProp: { [key: string]: number };
   }
 }

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithDirectDictionaryProp_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithDirectDictionaryProp_ShouldRenderToTypescriptMap.approved.txt
@@ -1,5 +1,4 @@
-declare module 'Api' {
-  export interface TypeWithDictionaryProp {
-    dictProp: { [key: string]: number };
-  }
+export interface TypeWithDictionaryProp {
+  dictProp: { [key: string]: number };
 }
+

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithEnumValueType_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithEnumValueType_ShouldRenderToTypescriptMap.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithDictionaryAndEnumPropAsValue {
+declare module 'Api' {
+  export interface TypeWithDictionaryAndEnumPropAsValue {
     enumDictionary: { [key: string]: 'FirstValue' | 'SecondValue' | 'ThirdValue' };
   }
 }

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithEnumValueType_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithEnumValueType_ShouldRenderToTypescriptMap.approved.txt
@@ -1,8 +1,7 @@
-declare module 'Api' {
-  export interface TypeWithDictionaryAndEnumPropAsValue {
-    enumDictionary: { [key: string]: 'FirstValue' | 'SecondValue' | 'ThirdValue' };
-  }
+export interface TypeWithDictionaryAndEnumPropAsValue {
+  enumDictionary: { [key: string]: 'FirstValue' | 'SecondValue' | 'ThirdValue' };
 }
+
 
 ---
 enum TestEnum {

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithEnumAndEnumValueFormatter_RendersValues.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithEnumAndEnumValueFormatter_RendersValues.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithValuedEnum {
+declare module 'Api' {
+  export interface TypeWithValuedEnum {
     enumWithValueProp: 'First' | 'Second' | 'Third';
   }
 }

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithEnumAndEnumValueFormatter_RendersValues.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithEnumAndEnumValueFormatter_RendersValues.approved.txt
@@ -1,8 +1,7 @@
-declare module 'Api' {
-  export interface TypeWithValuedEnum {
-    enumWithValueProp: 'First' | 'Second' | 'Third';
-  }
+export interface TypeWithValuedEnum {
+  enumWithValueProp: 'First' | 'Second' | 'Third';
 }
+
 
 ---
 enum EnumType {

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithEnum_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithEnum_GeneratesSuccessfully.approved.txt
@@ -1,8 +1,7 @@
-declare module 'Api' {
-  export interface TypeWithEnum {
-    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
-  }
+export interface TypeWithEnum {
+  anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
 }
+
 
 ---
 enum EnumType {

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithEnum_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithEnum_GeneratesSuccessfully.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithEnum {
+declare module 'Api' {
+  export interface TypeWithEnum {
     anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
   }
 }

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithNullableEnum_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithNullableEnum_GeneratesSuccessfully.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithNullableEnum {
+declare module 'Api' {
+  export interface TypeWithNullableEnum {
     nullableEnumProp: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum' | null;
   }
 }

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithNullableEnum_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypeWithNullableEnum_GeneratesSuccessfully.approved.txt
@@ -1,8 +1,7 @@
-declare module 'Api' {
-  export interface TypeWithNullableEnum {
-    nullableEnumProp: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum' | null;
-  }
+export interface TypeWithNullableEnum {
+  nullableEnumProp: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum' | null;
 }
+
 
 ---
 enum EnumType {

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyDecorateTheEnumOnce.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyDecorateTheEnumOnce.approved.txt
@@ -1,10 +1,10 @@
-declare namespace Api {
+declare module 'Api' {
   // Source: Typescript.Tests.Enums.EnumGeneratorTests+TypeTwoWithEnum
-  interface TypeTwoWithEnum {
+  export interface TypeTwoWithEnum {
     anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
   }
   // Source: Typescript.Tests.Enums.EnumGeneratorTests+TypeOneWithEnum
-  interface TypeOneWithEnum {
+  export interface TypeOneWithEnum {
     anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
   }
 }

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyDecorateTheEnumOnce.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyDecorateTheEnumOnce.approved.txt
@@ -1,13 +1,12 @@
-declare module 'Api' {
-  // Source: Typescript.Tests.Enums.EnumGeneratorTests+TypeTwoWithEnum
-  export interface TypeTwoWithEnum {
-    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
-  }
-  // Source: Typescript.Tests.Enums.EnumGeneratorTests+TypeOneWithEnum
-  export interface TypeOneWithEnum {
-    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
-  }
+// Source: Typescript.Tests.Enums.EnumGeneratorTests+TypeTwoWithEnum
+export interface TypeTwoWithEnum {
+  anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
 }
+// Source: Typescript.Tests.Enums.EnumGeneratorTests+TypeOneWithEnum
+export interface TypeOneWithEnum {
+  anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
+}
+
 
 ---
 // Source: Typescript.Tests.Enums.EnumGeneratorTests+SharedEnumType

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyGenerateTheEnumOnce.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyGenerateTheEnumOnce.approved.txt
@@ -1,8 +1,8 @@
-declare namespace Api {
-  interface TypeTwoWithEnum {
+declare module 'Api' {
+  export interface TypeTwoWithEnum {
     anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
   }
-  interface TypeOneWithEnum {
+  export interface TypeOneWithEnum {
     anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
   }
 }

--- a/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyGenerateTheEnumOnce.approved.txt
+++ b/src/Typescript.Tests/Enums/EnumGeneratorTests.Generator_TypesWithSharedEnum_ShouldOnlyGenerateTheEnumOnce.approved.txt
@@ -1,11 +1,10 @@
-declare module 'Api' {
-  export interface TypeTwoWithEnum {
-    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
-  }
-  export interface TypeOneWithEnum {
-    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
-  }
+export interface TypeTwoWithEnum {
+  anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
 }
+export interface TypeOneWithEnum {
+  anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
+}
+
 
 ---
 enum SharedEnumType {

--- a/src/Typescript.Tests/Generics/GenericsGeneratorTests.Generator_TypeWithGenericArguments_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Generics/GenericsGeneratorTests.Generator_TypeWithGenericArguments_GeneratesSuccessfully.approved.txt
@@ -1,6 +1,6 @@
-declare namespace Api {
-  interface TypeWithGenericArguments extends BaseType<Alpha, Beta> {
+declare module 'Api' {
+  export interface TypeWithGenericArguments extends BaseType<Alpha, Beta> {
   }
-  interface BaseType<T1, T2> {
+  export interface BaseType<T1, T2> {
   }
 }

--- a/src/Typescript.Tests/Generics/GenericsGeneratorTests.Generator_TypeWithGenericArguments_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Generics/GenericsGeneratorTests.Generator_TypeWithGenericArguments_GeneratesSuccessfully.approved.txt
@@ -1,6 +1,5 @@
-declare module 'Api' {
-  export interface TypeWithGenericArguments extends BaseType<Alpha, Beta> {
-  }
-  export interface BaseType<T1, T2> {
-  }
+export interface TypeWithGenericArguments extends BaseType<Alpha, Beta> {
 }
+export interface BaseType<T1, T2> {
+}
+

--- a/src/Typescript.Tests/Generics/GenericsGeneratorTests.Generator_TypeWithOpenGenericArguments_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Generics/GenericsGeneratorTests.Generator_TypeWithOpenGenericArguments_GeneratesSuccessfully.approved.txt
@@ -1,4 +1,3 @@
-declare module 'Api' {
-  export interface TypeWithOpenGenericArguments<T> {
-  }
+export interface TypeWithOpenGenericArguments<T> {
 }
+

--- a/src/Typescript.Tests/Generics/GenericsGeneratorTests.Generator_TypeWithOpenGenericArguments_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Generics/GenericsGeneratorTests.Generator_TypeWithOpenGenericArguments_GeneratesSuccessfully.approved.txt
@@ -1,4 +1,4 @@
-declare namespace Api {
-  interface TypeWithOpenGenericArguments<T> {
+declare module 'Api' {
+  export interface TypeWithOpenGenericArguments<T> {
   }
 }

--- a/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.Generator_TypeWithBaseClass_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.Generator_TypeWithBaseClass_GeneratesSuccessfully.approved.txt
@@ -1,7 +1,7 @@
-declare namespace Api {
-  interface TypeWithBaseClass extends BaseClass {
+declare module 'Api' {
+  export interface TypeWithBaseClass extends BaseClass {
   }
-  interface BaseClass {
+  export interface BaseClass {
     property: string;
   }
 }

--- a/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.Generator_TypeWithBaseClass_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Inheritence/InheritenceGeneratorTests.Generator_TypeWithBaseClass_GeneratesSuccessfully.approved.txt
@@ -1,7 +1,6 @@
-declare module 'Api' {
-  export interface TypeWithBaseClass extends BaseClass {
-  }
-  export interface BaseClass {
-    property: string;
-  }
+export interface TypeWithBaseClass extends BaseClass {
 }
+export interface BaseClass {
+  property: string;
+}
+

--- a/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNestedNullable_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNestedNullable_GeneratesSuccessfully.approved.txt
@@ -1,8 +1,8 @@
-declare namespace Api {
-  interface TypeWithNestedNullable {
+declare module 'Api' {
+  export interface TypeWithNestedNullable {
     nestedThing: NestedType;
   }
-  interface NestedType {
+  export interface NestedType {
     nullableInt: number | null;
     nullableDateTime: string;
   }

--- a/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNestedNullable_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNestedNullable_GeneratesSuccessfully.approved.txt
@@ -1,9 +1,8 @@
-declare module 'Api' {
-  export interface TypeWithNestedNullable {
-    nestedThing: NestedType;
-  }
-  export interface NestedType {
-    nullableInt: number | null;
-    nullableDateTime: string;
-  }
+export interface TypeWithNestedNullable {
+  nestedThing: NestedType;
 }
+export interface NestedType {
+  nullableInt: number | null;
+  nullableDateTime: string;
+}
+

--- a/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullable_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullable_GeneratesSuccessfully.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithNullable {
+declare module 'Api' {
+  export interface TypeWithNullable {
     nullableInt: number | null;
     nullableGuid: string | null;
   }

--- a/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullable_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullable_GeneratesSuccessfully.approved.txt
@@ -1,6 +1,5 @@
-declare module 'Api' {
-  export interface TypeWithNullable {
-    nullableInt: number | null;
-    nullableGuid: string | null;
-  }
+export interface TypeWithNullable {
+  nullableInt: number | null;
+  nullableGuid: string | null;
 }
+

--- a/src/Typescript.Tests/Simple/MemberFilterTests.WhenFilterSpecified_PropertyIsIgnored.approved.txt
+++ b/src/Typescript.Tests/Simple/MemberFilterTests.WhenFilterSpecified_PropertyIsIgnored.approved.txt
@@ -1,7 +1,6 @@
-declare module 'Api' {
-  export interface SimpleClass {
-    serializedType: number;
-  }
+export interface SimpleClass {
+  serializedType: number;
 }
+
 
 ---

--- a/src/Typescript.Tests/Simple/MemberFilterTests.WhenFilterSpecified_PropertyIsIgnored.approved.txt
+++ b/src/Typescript.Tests/Simple/MemberFilterTests.WhenFilterSpecified_PropertyIsIgnored.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface SimpleClass {
+declare module 'Api' {
+  export interface SimpleClass {
     serializedType: number;
   }
 }

--- a/src/Typescript.Tests/Simple/MemberFilterTests.WhenNoFilterSpecified_TypeIsEmitted.approved.txt
+++ b/src/Typescript.Tests/Simple/MemberFilterTests.WhenNoFilterSpecified_TypeIsEmitted.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface SimpleClass {
+declare module 'Api' {
+  export interface SimpleClass {
     serializedType: number;
     ignoredType: number;
   }

--- a/src/Typescript.Tests/Simple/MemberFilterTests.WhenNoFilterSpecified_TypeIsEmitted.approved.txt
+++ b/src/Typescript.Tests/Simple/MemberFilterTests.WhenNoFilterSpecified_TypeIsEmitted.approved.txt
@@ -1,8 +1,7 @@
-declare module 'Api' {
-  export interface SimpleClass {
-    serializedType: number;
-    ignoredType: number;
-  }
+export interface SimpleClass {
+  serializedType: number;
+  ignoredType: number;
 }
+
 
 ---

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithBuiltInPropsOnly_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithBuiltInPropsOnly_GeneratesSuccessfully.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface SimpleTypesOnly {
+declare module 'Api' {
+  export interface SimpleTypesOnly {
     intType: number;
     longType: number;
     stringType: string;

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithBuiltInPropsOnly_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithBuiltInPropsOnly_GeneratesSuccessfully.approved.txt
@@ -1,8 +1,7 @@
-declare module 'Api' {
-  export interface SimpleTypesOnly {
-    intType: number;
-    longType: number;
-    stringType: string;
-    decimalType: number;
-  }
+export interface SimpleTypesOnly {
+  intType: number;
+  longType: number;
+  stringType: string;
+  decimalType: number;
 }
+

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithCustomValueTypeProp_ShouldRenderCustomTypeSeparately.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithCustomValueTypeProp_ShouldRenderCustomTypeSeparately.approved.txt
@@ -1,8 +1,7 @@
-declare module 'Api' {
-  export interface TypeWithCustomValueTypeProp {
-    testStructProp: TestStruct;
-  }
-  export interface TestStruct {
-    intProp: number;
-  }
+export interface TypeWithCustomValueTypeProp {
+  testStructProp: TestStruct;
 }
+export interface TestStruct {
+  intProp: number;
+}
+

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithCustomValueTypeProp_ShouldRenderCustomTypeSeparately.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithCustomValueTypeProp_ShouldRenderCustomTypeSeparately.approved.txt
@@ -1,8 +1,8 @@
-declare namespace Api {
-  interface TypeWithCustomValueTypeProp {
+declare module 'Api' {
+  export interface TypeWithCustomValueTypeProp {
     testStructProp: TestStruct;
   }
-  interface TestStruct {
+  export interface TestStruct {
     intProp: number;
   }
 }

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithFieldsAndPropsButSetToPropsOnly_ShouldOnlyRenderProps.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithFieldsAndPropsButSetToPropsOnly_ShouldOnlyRenderProps.approved.txt
@@ -1,5 +1,4 @@
-declare module 'Api' {
-  export interface TestTypeWithFieldsAndProps {
-    stringProp: string;
-  }
+export interface TestTypeWithFieldsAndProps {
+  stringProp: string;
 }
+

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithFieldsAndPropsButSetToPropsOnly_ShouldOnlyRenderProps.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithFieldsAndPropsButSetToPropsOnly_ShouldOnlyRenderProps.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TestTypeWithFieldsAndProps {
+declare module 'Api' {
+  export interface TestTypeWithFieldsAndProps {
     stringProp: string;
   }
 }

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithFields_ShouldRenderFields.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithFields_ShouldRenderFields.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TestTypeWithFields {
+declare module 'Api' {
+  export interface TestTypeWithFields {
     stringField: string;
     intField: number;
   }

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithFields_ShouldRenderFields.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithFields_ShouldRenderFields.approved.txt
@@ -1,6 +1,5 @@
-declare module 'Api' {
-  export interface TestTypeWithFields {
-    stringField: string;
-    intField: number;
-  }
+export interface TestTypeWithFields {
+  stringField: string;
+  intField: number;
 }
+

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithHiddenInnerType_OnlyPublicPropertiesShouldBeRendered.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithHiddenInnerType_OnlyPublicPropertiesShouldBeRendered.approved.txt
@@ -1,5 +1,5 @@
-declare namespace Api {
-  interface TypeWithPrivateProperties {
+declare module 'Api' {
+  export interface TypeWithPrivateProperties {
     publicGuidProp: string;
   }
 }

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithHiddenInnerType_OnlyPublicPropertiesShouldBeRendered.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithHiddenInnerType_OnlyPublicPropertiesShouldBeRendered.approved.txt
@@ -1,5 +1,4 @@
-declare module 'Api' {
-  export interface TypeWithPrivateProperties {
-    publicGuidProp: string;
-  }
+export interface TypeWithPrivateProperties {
+  publicGuidProp: string;
 }
+

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithNestedSimpleTypes_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithNestedSimpleTypes_GeneratesSuccessfully.approved.txt
@@ -1,11 +1,10 @@
-declare module 'Api' {
-  export interface TypeWithNestedType {
-    simpleType: SimpleTypesOnly;
-  }
-  export interface SimpleTypesOnly {
-    intType: number;
-    longType: number;
-    stringType: string;
-    decimalType: number;
-  }
+export interface TypeWithNestedType {
+  simpleType: SimpleTypesOnly;
 }
+export interface SimpleTypesOnly {
+  intType: number;
+  longType: number;
+  stringType: string;
+  decimalType: number;
+}
+

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithNestedSimpleTypes_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithNestedSimpleTypes_GeneratesSuccessfully.approved.txt
@@ -1,8 +1,8 @@
-declare namespace Api {
-  interface TypeWithNestedType {
+declare module 'Api' {
+  export interface TypeWithNestedType {
     simpleType: SimpleTypesOnly;
   }
-  interface SimpleTypesOnly {
+  export interface SimpleTypesOnly {
     intType: number;
     longType: number;
     stringType: string;

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_UsingModule_ShouldRenderESModule.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_UsingModule_ShouldRenderESModule.approved.txt
@@ -1,0 +1,4 @@
+declare module 'Api' {
+  export interface TestTypeWithFields {
+  }
+}

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.cs
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.cs
@@ -20,7 +20,7 @@ namespace Typescript.Tests.Simple
         public void Generator_TypeWithBuiltInPropsOnly_GeneratesSuccessfully()
         {
             var generator = TypeScriptGenerator.CreateDefault();
-            var generated = generator.Generate(new[] {typeof(SimpleTypesOnly)});
+            var generated = generator.Generate(new[] { typeof(SimpleTypesOnly) });
 
             this.Assent(generated.Types);
         }
@@ -34,7 +34,7 @@ namespace Typescript.Tests.Simple
         public void Generator_TypeWithNestedSimpleTypes_GeneratesSuccessfully()
         {
             var generator = TypeScriptGenerator.CreateDefault();
-            var generated = generator.Generate(new[] {typeof(TypeWithNestedType)});
+            var generated = generator.Generate(new[] { typeof(TypeWithNestedType) });
 
             this.Assent(generated.Types);
         }
@@ -42,8 +42,7 @@ namespace Typescript.Tests.Simple
         class TypeWithPrivateProperties
         {
             private class HiddenInnerType
-            {
-            }
+            { }
 
             private string PrivateStringProp { get; set; }
             private int PrivateIntProp { get; set; }
@@ -55,7 +54,7 @@ namespace Typescript.Tests.Simple
         public void Generator_TypeWithHiddenInnerType_OnlyPublicPropertiesShouldBeRendered()
         {
             var generator = TypeScriptGenerator.CreateDefault();
-            var generated = generator.Generate(new[] {typeof(TypeWithPrivateProperties)});
+            var generated = generator.Generate(new[] { typeof(TypeWithPrivateProperties) });
 
             this.Assent(generated.Types);
         }
@@ -64,7 +63,7 @@ namespace Typescript.Tests.Simple
         {
             public int IntProp { get; }
         }
-        
+
         class TypeWithCustomValueTypeProp
         {
             public TestStruct TestStructProp { get; set; }
@@ -74,7 +73,7 @@ namespace Typescript.Tests.Simple
         public void Generator_TypeWithCustomValueTypeProp_ShouldRenderCustomTypeSeparately()
         {
             var generator = TypeScriptGenerator.CreateDefault();
-            var generated = generator.Generate(new[] {typeof(TypeWithCustomValueTypeProp)});
+            var generated = generator.Generate(new[] { typeof(TypeWithCustomValueTypeProp) });
 
             this.Assent(generated.Types);
         }
@@ -93,11 +92,11 @@ namespace Typescript.Tests.Simple
         {
             var generator = TypeScriptGenerator.CreateDefault()
                 .WithTypeMembers(MemberType.PropertiesAndFields);
-            var generated = generator.Generate(new[] {typeof(TestTypeWithFields)});
+            var generated = generator.Generate(new[] { typeof(TestTypeWithFields) });
 
             this.Assent(generated.Types);
         }
-        
+
         class TestTypeWithFieldsAndProps
         {
 #pragma warning disable 414
@@ -111,7 +110,17 @@ namespace Typescript.Tests.Simple
         public void Generator_TypeWithFieldsAndPropsButSetToPropsOnly_ShouldOnlyRenderProps()
         {
             var generator = TypeScriptGenerator.CreateDefault();
-            var generated = generator.Generate(new[] {typeof(TestTypeWithFieldsAndProps)});
+            var generated = generator.Generate(new[] { typeof(TestTypeWithFieldsAndProps) });
+
+            this.Assent(generated.Types);
+        }
+
+        [Fact]
+        public void Generator_UsingModule_ShouldRenderESModule()
+        {
+            var generator = TypeScriptGenerator.CreateDefault()
+                .WithModule("Api");
+            var generated = generator.Generate(new []{ typeof(TestTypeWithFields) });
 
             this.Assent(generated.Types);
         }

--- a/src/Typescript.Tests/Simple/TypeDecoratorTests.Generator_CommentDecoration_GenerateSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Simple/TypeDecoratorTests.Generator_CommentDecoration_GenerateSuccessfully.approved.txt
@@ -1,20 +1,19 @@
-declare module 'Api' {
-  // Source: Typescript.Tests.Simple.TypeDecoratorTests+TypeWithEnum
-  export interface TypeWithEnum {
-    anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
-  }
-  // Source: Typescript.Tests.Simple.TypeDecoratorTests+TypeWithNestedType
-  export interface TypeWithNestedType {
-    simpleType: SimpleTypesOnly;
-  }
-  // Source: Typescript.Tests.Simple.TypeDecoratorTests+SimpleTypesOnly
-  export interface SimpleTypesOnly {
-    intType: number;
-    longType: number;
-    stringType: string;
-    decimalType: number;
-  }
+// Source: Typescript.Tests.Simple.TypeDecoratorTests+TypeWithEnum
+export interface TypeWithEnum {
+  anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
 }
+// Source: Typescript.Tests.Simple.TypeDecoratorTests+TypeWithNestedType
+export interface TypeWithNestedType {
+  simpleType: SimpleTypesOnly;
+}
+// Source: Typescript.Tests.Simple.TypeDecoratorTests+SimpleTypesOnly
+export interface SimpleTypesOnly {
+  intType: number;
+  longType: number;
+  stringType: string;
+  decimalType: number;
+}
+
 
 ---
 // Source: Typescript.Tests.Simple.TypeDecoratorTests+EnumType

--- a/src/Typescript.Tests/Simple/TypeDecoratorTests.Generator_CommentDecoration_GenerateSuccessfully.approved.txt
+++ b/src/Typescript.Tests/Simple/TypeDecoratorTests.Generator_CommentDecoration_GenerateSuccessfully.approved.txt
@@ -1,14 +1,14 @@
-declare namespace Api {
+declare module 'Api' {
   // Source: Typescript.Tests.Simple.TypeDecoratorTests+TypeWithEnum
-  interface TypeWithEnum {
+  export interface TypeWithEnum {
     anEnum: 'FirstEnum' | 'SecondEnum' | 'ThirdEnum';
   }
   // Source: Typescript.Tests.Simple.TypeDecoratorTests+TypeWithNestedType
-  interface TypeWithNestedType {
+  export interface TypeWithNestedType {
     simpleType: SimpleTypesOnly;
   }
   // Source: Typescript.Tests.Simple.TypeDecoratorTests+SimpleTypesOnly
-  interface SimpleTypesOnly {
+  export interface SimpleTypesOnly {
     intType: number;
     longType: number;
     stringType: string;

--- a/src/Typescriptr/TypeScriptGenerator.cs
+++ b/src/Typescriptr/TypeScriptGenerator.cs
@@ -55,6 +55,7 @@ namespace Typescriptr
             {typeof(DayOfWeek), "string"},
             {typeof(TimeSpan), "string"},
             {typeof(Guid), "string"},
+            {typeof(object), "unknown"}
         };
 
         private TypeScriptGenerator()
@@ -157,7 +158,7 @@ namespace Typescriptr
             if (!string.IsNullOrEmpty(_namespace))
             {
                 typeBuilder = new StringBuilder(typeBuilder.ToString().IndentEachLine(TabString));
-                typeBuilder.PrependLine($"declare namespace {_namespace} {{");
+                typeBuilder.PrependLine($"declare module '{_namespace}' {{");
                 typeBuilder.AppendLine("}");
             }
             else
@@ -200,7 +201,7 @@ namespace Typescriptr
             if (_typeDecorator != null)
                 builder.AppendLine(_typeDecorator(type));
 
-            builder.Append($"interface ");
+            builder.Append($"export interface ");
             RenderTypeName(builder, type);
             if (hasBaseType) {
                 builder.Append($" extends ");

--- a/src/Typescriptr/TypeScriptGenerator.cs
+++ b/src/Typescriptr/TypeScriptGenerator.cs
@@ -70,7 +70,6 @@ namespace Typescriptr
             .WithTypeMembers(MemberType.PropertiesOnly)
             .WithDictionaryPropertyFormatter(DictionaryPropertyFormatter.KeyValueFormatter)
             .WithCollectionPropertyFormatter(CollectionPropertyFormatter.Format)
-            .WithNamespace("Api")
             .WithCamelCasedPropertyNames();
 
         public TypeScriptGenerator WithTypeMembers(MemberType memberTypes)
@@ -97,9 +96,9 @@ namespace Typescriptr
             return this;
         }
 
-        public TypeScriptGenerator WithNamespace(string @namespace)
+        public TypeScriptGenerator WithModule(string module)
         {
-            _namespace = @namespace;
+            _module = module;
             return this;
         }
 
@@ -136,7 +135,7 @@ namespace Typescriptr
         private readonly HashSet<Type> _typesGenerated = new HashSet<Type>();
         private readonly HashSet<string> _enumNames = new HashSet<string>();
         private readonly Stack<Type> _typeStack = new Stack<Type>();
-        private string _namespace;
+        private string _module;
         
 
         public GenerationResult Generate(IEnumerable<Type> types)
@@ -155,10 +154,10 @@ namespace Typescriptr
                 else RenderType(typeBuilder, type);
             }
 
-            if (!string.IsNullOrEmpty(_namespace))
+            if (!string.IsNullOrEmpty(_module))
             {
                 typeBuilder = new StringBuilder(typeBuilder.ToString().IndentEachLine(TabString));
-                typeBuilder.PrependLine($"declare module '{_namespace}' {{");
+                typeBuilder.PrependLine($"declare module '{_module}' {{");
                 typeBuilder.AppendLine("}");
             }
             else

--- a/src/Typescriptr/Typescriptr.csproj
+++ b/src/Typescriptr/Typescriptr.csproj
@@ -15,7 +15,7 @@
         </Description>
         <PackageProjectUrl>https://github.com/gkinsman/Typescriptr</PackageProjectUrl>
         <RepositoryUrl>https://github.com/gkinsman/Typescriptr</RepositoryUrl>
-        <PackageLicenseUrl>https://github.com/gkinsman/Typescriptr/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Typescriptr/Typescriptr.csproj
+++ b/src/Typescriptr/Typescriptr.csproj
@@ -2,8 +2,9 @@
 
     <PropertyGroup>
         <Configurations>Debug;ReleaseWindows;ReleaseLinux</Configurations>
-        <TargetFrameworks Condition="'$(Configuration)'=='ReleaseWindows'">net45;netstandard2.0</TargetFrameworks>
-        <TargetFrameworks Condition="'$(Configuration)'=='ReleaseLinux'">netstandard2.0</TargetFrameworks>
+        <TargetFramework Condition="'$(Configuration)' == 'Debug'">netstandard2.0</TargetFramework>
+        <TargetFrameworks Condition="'$(Configuration)'=='ReleaseWindows'">net461;netstandard2.0</TargetFrameworks>
+        <TargetFramework Condition="'$(Configuration)'=='ReleaseLinux'">netstandard2.0</TargetFramework>
         <Platforms>AnyCPU</Platforms>
     </PropertyGroup>
 


### PR DESCRIPTION
This PR switches off the default module nesting so that all members are exported from the top level by default. This makes it easier for users as there's no longer an additional de-reference required.

It also changes the export (when enabled) to modules instead of namespaces.

e.g.

```typescript
declare namespace Api {
  interface TestTypeWithFields {
  }
}
```
=>
```typescript
declare module 'Api' {
  export interface TestTypeWithFields {
  }
}
```