### PR TITLE
feat!: support nullable reference types in generated TypeScript

### DIFF
--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithIDictionaryProp_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithIDictionaryProp_ShouldRenderToTypescriptMap.approved.txt
@@ -1,0 +1,4 @@
+export interface TypeWithIDictionaryProp {
+  dictProp: { [key: string]: number };
+}
+

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithIReadOnlyDictionaryProp_ShouldRenderToTypescriptMap.approved.txt
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.Generator_TypeWithIReadOnlyDictionaryProp_ShouldRenderToTypescriptMap.approved.txt
@@ -1,0 +1,4 @@
+export interface TypeWithIReadOnlyDictionaryProp {
+  dictProp: { [key: string]: number };
+}
+

--- a/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.cs
+++ b/src/Typescript.Tests/DictionaryTypes/DictionaryGeneratorTests.cs
@@ -16,16 +16,45 @@ namespace Typescript.Tests.DictionaryTypes
         public void Generator_TypeWithDirectDictionaryProp_ShouldRenderToTypescriptMap()
         {
             var generator = TypeScriptGenerator.CreateDefault();
-            var generated = generator.Generate(new[] {typeof(TypeWithDictionaryProp)});
+            var generated = generator.Generate(new[] { typeof(TypeWithDictionaryProp) });
 
             this.Assent(generated.Types);
         }
+
+        class TypeWithIDictionaryProp
+        {
+            public IDictionary<string, int> DictProp { get; set; }
+        }
+
+        [Fact]
+        public void Generator_TypeWithIDictionaryProp_ShouldRenderToTypescriptMap()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] { typeof(TypeWithIDictionaryProp) });
+
+            this.Assent(generated.Types);
+        }
+
+        class TypeWithIReadOnlyDictionaryProp
+        {
+            public IReadOnlyDictionary<string, int> DictProp { get; set; }
+        }
+
+        [Fact]
+        public void Generator_TypeWithIReadOnlyDictionaryProp_ShouldRenderToTypescriptMap()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] { typeof(TypeWithIReadOnlyDictionaryProp) });
+
+            this.Assent(generated.Types);
+        }
+
 
         class ComplexType
         {
             public string AProp { get; set; }
         }
-        
+
         class TypeWithComplexDictionaryValue
         {
             public Dictionary<int, ComplexType> DictProp { get; set; }
@@ -35,7 +64,7 @@ namespace Typescript.Tests.DictionaryTypes
         public void Generator_TypeWithComplexDictionaryValueType_ShouldRenderToTypescriptMap()
         {
             var generator = TypeScriptGenerator.CreateDefault();
-            var generated = generator.Generate(new[] {typeof(TypeWithComplexDictionaryValue)});
+            var generated = generator.Generate(new[] { typeof(TypeWithComplexDictionaryValue) });
 
             this.Assent(generated.Types);
         }
@@ -48,12 +77,12 @@ namespace Typescript.Tests.DictionaryTypes
         interface ICustomDictionary : IDictionary<string, int>
         {
         }
-        
+
         [Fact]
         public void Generator_TypeWithCustomDictionaryValueType_ShouldRenderToTypescriptMap()
         {
             var generator = TypeScriptGenerator.CreateDefault();
-            var generated = generator.Generate(new[] {typeof(TypeWithCustomDictionaryProp)});
+            var generated = generator.Generate(new[] { typeof(TypeWithCustomDictionaryProp) });
 
             this.Assent(generated.JoinTypesAndEnums());
         }
@@ -69,12 +98,12 @@ namespace Typescript.Tests.DictionaryTypes
         {
             public Dictionary<string, TestEnum> EnumDictionary { get; set; }
         }
-        
+
         [Fact]
         public void Generator_TypeWithEnumValueType_ShouldRenderToTypescriptMap()
         {
             var generator = TypeScriptGenerator.CreateDefault();
-            var generated = generator.Generate(new[] {typeof(TypeWithDictionaryAndEnumPropAsValue)});
+            var generated = generator.Generate(new[] { typeof(TypeWithDictionaryAndEnumPropAsValue) });
 
             this.Assent(generated.JoinTypesAndEnums());
         }

--- a/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullableDictionaryValue_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullableDictionaryValue_GeneratesSuccessfully.approved.txt
@@ -1,0 +1,6 @@
+export interface TypeWithNullableDictionaryValue {
+  map: { [key: string]: ReferenceType | null };
+}
+export interface ReferenceType {
+}
+

--- a/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullableInCollection_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullableInCollection_GeneratesSuccessfully.approved.txt
@@ -1,0 +1,4 @@
+export interface TypeWithNullableInCollection {
+  tags: (string | null)[];
+}
+

--- a/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullableReferenceType_GeneratesSuccessfully.approved.txt
+++ b/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.Generator_TypeWithNullableReferenceType_GeneratesSuccessfully.approved.txt
@@ -1,0 +1,6 @@
+export interface TypeWithNullableReferenceType {
+  referenceType: ReferenceType | null;
+}
+export interface ReferenceType {
+}
+

--- a/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.cs
+++ b/src/Typescript.Tests/NullableTypes/NullableTypeGeneratorTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Assent;
 using Typescriptr;
@@ -13,6 +14,7 @@ namespace Typescript.Tests.NullableTypes
             public Guid? NullableGuid { get; set; }
         }
 
+        
         [Fact]
         public void Generator_TypeWithNullable_GeneratesSuccessfully()
         {
@@ -30,7 +32,7 @@ namespace Typescript.Tests.NullableTypes
                 public DateTime NullableDateTime { get; set; }
             }
 
-            public NestedType NestedThing { get; set; }
+            public NestedType NestedThing { get; set; } = null!;
         }
 
         [Fact]
@@ -38,6 +40,50 @@ namespace Typescript.Tests.NullableTypes
         {
             var generator = TypeScriptGenerator.CreateDefault();
             var generated = generator.Generate(new[] {typeof(TypeWithNestedNullable)});
+
+            this.Assent(generated.Types);
+        }
+
+        class ReferenceType {}
+
+        class TypeWithNullableReferenceType
+        {
+            public ReferenceType? ReferenceType { get; set; }
+        }
+
+        [Fact]
+        public void Generator_TypeWithNullableReferenceType_GeneratesSuccessfully()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] {typeof(TypeWithNullableReferenceType)});
+
+            this.Assent(generated.Types);
+        }
+
+        class TypeWithNullableInCollection
+        {
+            public System.Collections.Generic.List<string?> Tags { get; set; } = null!;
+        }
+
+        [Fact]
+        public void Generator_TypeWithNullableInCollection_GeneratesSuccessfully()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] {typeof(TypeWithNullableInCollection)});
+
+            this.Assent(generated.Types);
+        }
+
+        class TypeWithNullableDictionaryValue
+        {
+            public System.Collections.Generic.IDictionary<string, ReferenceType?> Map { get; set; } = null!;
+        }
+
+        [Fact]
+        public void Generator_TypeWithNullableDictionaryValue_GeneratesSuccessfully()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] {typeof(TypeWithNullableDictionaryValue)});
 
             this.Assent(generated.Types);
         }

--- a/src/Typescript.Tests/Typescript.Tests.csproj
+++ b/src/Typescript.Tests/Typescript.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/src/Typescriptr/Formatters/CollectionPropertyFormatter.cs
+++ b/src/Typescriptr/Formatters/CollectionPropertyFormatter.cs
@@ -1,20 +1,31 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Typescriptr.Formatters
 {
     public class CollectionPropertyFormatter
     {
-        public static string Format(Type type, Func<Type, string> typeNameRenderer)
+        public static string Format(Type type, NullabilityInfo nullability, Func<Type, NullabilityInfo, string> typeNameRenderer)
         {
             var typeArgument =
                 type.GetElementType() ??
                 type.GenericTypeArguments.FirstOrDefault() ??
                 type.GetInterface(typeof(IEnumerable<>).Name).GenericTypeArguments.FirstOrDefault();
 
-            var renderedTypeName = typeNameRenderer(typeArgument);
-            return $"{renderedTypeName}[]";
+            // Element nullability lives in ElementType for arrays, GenericTypeArguments[0] for List<T> etc.
+            NullabilityInfo elementNullability = null;
+            if (nullability != null)
+                elementNullability = nullability.ElementType
+                    ?? (nullability.GenericTypeArguments.Length > 0 ? nullability.GenericTypeArguments[0] : null);
+
+            var renderedTypeName = typeNameRenderer(typeArgument, elementNullability);
+
+            // Parenthesise unions so the array marker binds correctly: (string | null)[], not string | null[].
+            return renderedTypeName.Contains(" | ")
+                ? $"({renderedTypeName})[]"
+                : $"{renderedTypeName}[]";
         }
     }
 }

--- a/src/Typescriptr/Formatters/DictionaryPropertyFormatter.cs
+++ b/src/Typescriptr/Formatters/DictionaryPropertyFormatter.cs
@@ -1,24 +1,43 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using Typescriptr.Exceptions;
 
 namespace Typescriptr.Formatters
 {
     public static class DictionaryPropertyFormatter
     {
-        public static string KeyValueFormatter(Type type, Func<Type, string> typeNameRenderer)
+        public static string KeyValueFormatter(Type type, NullabilityInfo nullability, Func<Type, NullabilityInfo, string> typeNameRenderer)
         {
-            var dictType = type.GetInterface(typeof(IDictionary<,>).Name);
+            var dictType = IsGenericDictionary(type)
+                ? type
+                : type.GetInterface(typeof(IDictionary<,>).Name)
+                  ?? type.GetInterface(typeof(IReadOnlyDictionary<,>).Name);
             var typeArguments = dictType.GenericTypeArguments;
             var keyType = typeArguments[0];
             var valueType = typeArguments[1];
 
-            var keyTypeName = typeNameRenderer(keyType);
-            var valueTypeName = typeNameRenderer(valueType);
+            // The key/value NullabilityInfo is only available when the declared member type is itself
+            // the generic dictionary (so the generic args line up); otherwise we have no NRT metadata.
+            NullabilityInfo keyNullability = null;
+            NullabilityInfo valueNullability = null;
+            if (nullability != null && nullability.GenericTypeArguments.Length == 2)
+            {
+                keyNullability = nullability.GenericTypeArguments[0];
+                valueNullability = nullability.GenericTypeArguments[1];
+            }
+
+            var keyTypeName = typeNameRenderer(keyType, keyNullability);
+            var valueTypeName = typeNameRenderer(valueType, valueNullability);
 
             var propString = $"{{ [key: {keyTypeName}]: {valueTypeName} }}";
             return propString;
         }
+
+        static bool IsGenericDictionary(Type type) =>
+            type.IsGenericType &&
+            (type.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+             type.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>));
     }
 }

--- a/src/Typescriptr/TypeScriptGenerator.cs
+++ b/src/Typescriptr/TypeScriptGenerator.cs
@@ -14,9 +14,9 @@ namespace Typescriptr
 
     public delegate string FormatEnumProperty(Type t, QuoteStyle quoteStyle);
 
-    public delegate string FormatDictionaryProperty(Type t, Func<Type, string> typeNameRenderer);
+    public delegate string FormatDictionaryProperty(Type t, NullabilityInfo nullability, Func<Type, NullabilityInfo, string> typeNameRenderer);
 
-    public delegate string FormatCollectionProperty(Type t, Func<Type, string> typeNameRenderer);
+    public delegate string FormatCollectionProperty(Type t, NullabilityInfo nullability, Func<Type, NullabilityInfo, string> typeNameRenderer);
 
     public delegate bool MemberFilter(MemberInfo memberInfo);
 
@@ -135,6 +135,7 @@ namespace Typescriptr
         private readonly HashSet<Type> _typesGenerated = new HashSet<Type>();
         private readonly HashSet<string> _enumNames = new HashSet<string>();
         private readonly Stack<Type> _typeStack = new Stack<Type>();
+        private readonly NullabilityInfoContext _nullabilityContext = new NullabilityInfoContext();
         private string _module;
         
 
@@ -212,12 +213,19 @@ namespace Typescriptr
             foreach (var memberInfo in members)
             {
                 Type memberType = null;
+                NullabilityInfo memberNullability = null;
                 if (memberInfo is PropertyInfo p)
+                {
                     memberType = p.PropertyType;
+                    memberNullability = _nullabilityContext.Create(p);
+                }
                 else if (memberInfo is FieldInfo f)
+                {
                     memberType = f.FieldType;
+                    memberNullability = _nullabilityContext.Create(f);
+                }
                 if (memberType == null) throw new InvalidOperationException();
-                
+
                 var memberName = memberInfo.Name;
                 if (_useCamelCasePropertyNames)
                     memberName = memberName.ToCamelCase();
@@ -226,7 +234,7 @@ namespace Typescriptr
 
                     if (_memberFilter == null || _memberFilter(memberInfo))
                     {
-                        RenderProperty(builder, memberType, memberName);
+                        RenderProperty(builder, memberType, memberNullability, memberName);
                     }
                 }
             }
@@ -261,24 +269,29 @@ namespace Typescriptr
             }
         }
 
-        private string TypeNameRenderer(Type type)
+        private string TypeNameRenderer(Type type, NullabilityInfo nullability)
         {
-            Func<string, string> decorate = str => str;
+            // Nullable value types (int?) are detected from the runtime type; nullable reference
+            // types (string?) only exist in metadata, so we read them from the member's NullabilityInfo.
+            var underlyingValueType = Nullable.GetUnderlyingType(type);
+            var isNullable = underlyingValueType != null
+                || (nullability != null
+                    && !type.IsValueType
+                    && nullability.ReadState == NullabilityState.Nullable);
 
-            if (Nullable.GetUnderlyingType(type) != null)
-            {
-                type = Nullable.GetUnderlyingType(type);
-                decorate = str => str + " | null";
-            }
+            if (underlyingValueType != null)
+                type = underlyingValueType;
+
+            Func<string, string> decorate = isNullable ? str => str + " | null" : str => str;
 
             if (_propTypeMap.ContainsKey(type))
                 return decorate(_propTypeMap[type]);
 
-            if (type.IsClosedTypeOf(typeof(IDictionary<,>)))
-                return decorate(_dictionaryPropertyFormatter(type, TypeNameRenderer));
+            if (type.IsClosedTypeOf(typeof(IDictionary<,>)) || type.IsClosedTypeOf(typeof(IReadOnlyDictionary<,>)))
+                return decorate(_dictionaryPropertyFormatter(type, nullability, TypeNameRenderer));
 
             if (typeof(IEnumerable).IsAssignableFrom(type))
-                return decorate(_collectionPropertyFormatter(type, TypeNameRenderer));
+                return decorate(_collectionPropertyFormatter(type, nullability, TypeNameRenderer));
 
             var typeName = type.Name;
             if (typeof(Enum).IsAssignableFrom(type))
@@ -289,9 +302,9 @@ namespace Typescriptr
             return decorate(typeName);
         }
 
-        private void RenderProperty(StringBuilder builder, Type propType, string propName)
+        private void RenderProperty(StringBuilder builder, Type propType, NullabilityInfo nullability, string propName)
         {
-            var propTypeName = TypeNameRenderer(propType);
+            var propTypeName = TypeNameRenderer(propType, nullability);
             builder.AppendLine($"{TabString}{propName}: {propTypeName};");
         }
 

--- a/src/Typescriptr/Typescriptr.csproj
+++ b/src/Typescriptr/Typescriptr.csproj
@@ -2,9 +2,8 @@
 
     <PropertyGroup>
         <Configurations>Debug;ReleaseWindows;ReleaseLinux</Configurations>
-        <TargetFramework Condition="'$(Configuration)' == 'Debug'">netstandard2.0</TargetFramework>
-        <TargetFrameworks Condition="'$(Configuration)'=='ReleaseWindows'">net461;netstandard2.0</TargetFrameworks>
-        <TargetFramework Condition="'$(Configuration)'=='ReleaseLinux'">netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
         <Platforms>AnyCPU</Platforms>
     </PropertyGroup>
 


### PR DESCRIPTION
Reference-type nullability (string?, Foo?) is read from member metadata via NullabilityInfoContext and emitted as `T | null`, consistent with the existing nullable value-type handling. Works at the top level and nested inside collections and dictionaries:

  ReferenceType? x           -> referenceType: ReferenceType | null
  List<string?>              -> tags: (string | null)[]
  IDictionary<string, Foo?>  -> map: { [key: string]: Foo | null }

Also renders IReadOnlyDictionary<,> as a TS map (previously emitted string[]).

The library now targets net8.0 (dropping net461/netstandard2.0) so that NullabilityInfoContext is available.

BREAKING CHANGE: the FormatDictionaryProperty and FormatCollectionProperty delegates now take an additional NullabilityInfo argument and a Func<Type, NullabilityInfo, string> renderer; custom formatters must update their signatures. The package no longer ships net461/netstandard2.0 targets (net8.0+ only).