### PR TITLE
Add default support for DateOnly/TimeOnly types

### DIFF
--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithDateAndTimeTypes_ShouldRenderAsStrings.approved.txt
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithDateAndTimeTypes_ShouldRenderAsStrings.approved.txt
@@ -1,0 +1,8 @@
+export interface TypeWithDateAndTimeTypes {
+  dateOnlyType: string;
+  dateTimeOffsetType: string;
+  dateTimeType: string;
+  timeOnlyType: string;
+  timeSpanType: string;
+}
+

--- a/src/Typescript.Tests/Simple/SimpleGeneratorTests.cs
+++ b/src/Typescript.Tests/Simple/SimpleGeneratorTests.cs
@@ -115,6 +115,24 @@ namespace Typescript.Tests.Simple
             this.Assent(generated.Types);
         }
 
+        class TypeWithDateAndTimeTypes
+        {
+            public DateTime DateTimeType { get; set; }
+            public DateTimeOffset DateTimeOffsetType { get; set; }
+            public DateOnly DateOnlyType { get; set; }
+            public TimeOnly TimeOnlyType { get; set; }
+            public TimeSpan TimeSpanType { get; set; }
+        }
+
+        [Fact]
+        public void Generator_TypeWithDateAndTimeTypes_ShouldRenderAsStrings()
+        {
+            var generator = TypeScriptGenerator.CreateDefault();
+            var generated = generator.Generate(new[] { typeof(TypeWithDateAndTimeTypes) });
+
+            this.Assent(generated.Types);
+        }
+
         [Fact]
         public void Generator_UsingModule_ShouldRenderESModule()
         {

--- a/src/Typescriptr/TypeScriptGenerator.cs
+++ b/src/Typescriptr/TypeScriptGenerator.cs
@@ -52,6 +52,8 @@ namespace Typescriptr
             {typeof(string), "string"},
             {typeof(bool), "boolean"},
             {typeof(DateTime), "string"},
+            {typeof(DateOnly), "string"},
+            {typeof(TimeOnly), "string"},
             {typeof(DayOfWeek), "string"},
             {typeof(TimeSpan), "string"},
             {typeof(Guid), "string"},


### PR DESCRIPTION
This pull request adds support for serializing .NET date and time types as strings in the TypeScript generator, and includes a new test to verify this behavior. The key changes ensure that types like `DateOnly`, `TimeOnly`, and others are correctly mapped to TypeScript `string` types.

**TypeScript type mapping improvements:**

* Updated the type mapping in `TypeScriptGenerator` to serialize `DateOnly` and `TimeOnly` as TypeScript `string` types. (`src/Typescriptr/TypeScriptGenerator.cs`, [src/Typescriptr/TypeScriptGenerator.csR55-R56](diffhunk://#diff-e66fd4fc99a0e36a1b2a97cb59a8711c018bae10828be6bb1dd6452249e96288R55-R56))
* Ensured that `TimeSpan` and `DateTimeOffset` continue to be mapped to TypeScript `string` types. (`src/Typescriptr/TypeScriptGenerator.cs`, [src/Typescriptr/TypeScriptGenerator.csR55-R56](diffhunk://#diff-e66fd4fc99a0e36a1b2a97cb59a8711c018bae10828be6bb1dd6452249e96288R55-R56))

**Testing enhancements:**

* Added a new test case, `Generator_TypeWithDateAndTimeTypes_ShouldRenderAsStrings`, to verify that .NET date and time types are rendered as TypeScript strings. (`src/Typescript.Tests/Simple/SimpleGeneratorTests.cs`, [src/Typescript.Tests/Simple/SimpleGeneratorTests.csR118-R135](diffhunk://#diff-07320d610d673d5dc320e6884ad37a5bbbcd1c7d8479cdc21cb00def9e3f5113R118-R135))
* Added a new approved test output file for the new test, confirming the correct TypeScript interface is generated for types with date and time properties. (`src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithDateAndTimeTypes_ShouldRenderAsStrings.approved.txt`, [src/Typescript.Tests/Simple/SimpleGeneratorTests.Generator_TypeWithDateAndTimeTypes_ShouldRenderAsStrings.approved.txtR1-R8](diffhunk://#diff-54ec2e6d9618edbd80ab93c16f39bed5e11c8959c21075a7d180a5460e4b3d0bR1-R8))